### PR TITLE
build_chain_new - always builds chains of requested length

### DIFF
--- a/utils_cmp_chain_building.py
+++ b/utils_cmp_chain_building.py
@@ -1,49 +1,48 @@
 import numpy as np
 import faiss
-from utils import build_chain_org, build_chain_alt
+from utils import build_chain_org, build_chain_alt, build_chain_new
 
 
 def cmp_chain_building():
     # test/compare chain building implementations
 
-    k = 5
+    k = 20
     np.random.seed(seed=6)
-    x = np.random.random((10, 2))  # random, but interesting data
+    x = np.random.random((7500, 100)).astype(np.float32)
 
     # # nearest neighbour object
     index = faiss.IndexFlatL2(x.shape[-1])
     neighbor_mask = np.ones(len(x))
     # # add nearest neighbour candidates
-    index.add(x[neighbor_mask==1])
+    index.add(x[neighbor_mask == 1])
 
     # # distances and idx of neighbour points for the neighbour candidates (k+1 as the first one will be the point itself)
-    dist_train, idx_train = index.search(x[neighbor_mask==1], k = k+1)
+    dist_train, idx_train = index.search(x[neighbor_mask == 1], k=k+1)
 
     # remove 1st nearest neighbours to remove self loops
-    dist_train, idx_train = dist_train[:,1:], idx_train[:,1:]  # no duplicates, so we can use this simplidied version
+    dist_train, idx_train = dist_train[:, 1:], idx_train[:, 1:]  # no duplicates, so we can use this simplidied version
 
     dist, idx = dist_train, idx_train
-    
-    # print('data points', x)
-    print('dist', dist)
-    print('idx = neighbours in order by distance')
-    for i, nbrs in enumerate(idx):
-        print(i, nbrs)
-    print()
 
-    for i in range(2): # len(idx)):
-        chain_length = len(idx[i])  # we need long chain
-        print(f'\nstart node={i}, chain_length={chain_length}')
+    pts_all = x[neighbor_mask == 1]
 
-        print('org implementation')
-        chain_distances, used = build_chain_org(dist, idx, i, chain_length, k=k)
-        print('used:', used)
-        print('chain_distances:', chain_distances)
+    from tqdm import tqdm  # optional prograss bar (since this part takes a while)
+    cnt_same_length = 0
+    for i in tqdm(range(len(idx))):
+        for ii in range(len(idx[i])):
+            chain_length = ii + 1
 
-        print('alt implementation')
-        chain_distances, used = build_chain_alt(dist, idx, i, chain_length)
-        print('used:', used)  # it has len+1 vs distances, bc there are more nodes than edges on path
-        print('chain_distances:', chain_distances)
+            chain_distances_new, used_new = build_chain_new(pts_all, idx, i, chain_length)
+
+            chain_distances_alt, used_alt = build_chain_alt(dist, idx, i, chain_length)
+            # chain_distances_org, used_org = build_chain_org(dist, idx, i, chain_length, k)
+
+            if len(used_alt) == len(used_new):
+                # if alt method found full chain, results are equal, except when there are duplicates/rounding errors
+                assert used_new == used_alt
+                assert np.allclose(chain_distances_new, chain_distances_alt, atol=1.e-6)
+                cnt_same_length += 1
+    print('confirmed chains of same length', cnt_same_length)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Using only distances from kNN its not possible to always build chains of requested length.
build_chain_new starts with neighbors of starting node (other nodes are never needed!) and calculates all pairwise distances.
Then applies normal chain building algorithm. This way it will use all starting neighbors (will order them according to greedy chain building algorithm).
As a test - it returns same results as build_chain_alt when both return chains of same length.
